### PR TITLE
去掉节次大于 10 的课程

### DIFF
--- a/Python/export_timetable.py
+++ b/Python/export_timetable.py
@@ -121,7 +121,7 @@ def get_courses_from_ehall():
         while len(courseList) < len(i['SKZC']):
             courseList.append([[], [], [], [], [], [], []])
         for j in range(len(i['SKZC'])):
-            if i['SKZC'][j] == '1':
+            if i['SKZC'][j] == '1' and int(i['KSJC']) <= 10 and int(i['JSJC']) <= 10:
                 courseList[j][int(i['SKXQ']) - 1].append({
                     'name': i['KCM'],
                     'location': i['JASMC'],


### PR DESCRIPTION
昨天退课之后重新导出课表，发现学业指导出现在了返回的 json 里，节次是 13、14。改了一下，只加入节次 1-10 的课程